### PR TITLE
Verify pub score and make releases idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,29 @@ permissions:
   contents: read
 
 jobs:
+  package-score:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          cache: true
+          pub-cache: true
+
+      - name: Install latest pana
+        run: dart pub global activate pana
+
+      - name: Require maximum pub points
+        run: dart pub global run pana . --exit-code-threshold 0
+
   quality:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,34 @@ jobs:
       - name: Validate package
         run: dart pub publish --dry-run
 
-  publish:
+  check-version:
     needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      published: ${{ steps.lookup.outputs.published }}
+
+    steps:
+      - name: Check whether the version is already published
+        id: lookup
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            "https://pub.dev/api/packages/morphnext/versions/${version}")"
+          case "${status}" in
+            200) echo "published=true" >> "${GITHUB_OUTPUT}" ;;
+            404) echo "published=false" >> "${GITHUB_OUTPUT}" ;;
+            *)
+              echo "pub.dev returned HTTP ${status}" >&2
+              exit 1
+              ;;
+          esac
+
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.published != 'true'
     permissions:
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@7654d458321ee25acccccfdb86cd48bd95768ff1 # v1.8.0
@@ -58,7 +84,11 @@ jobs:
       environment: pub.dev
 
   release:
-    needs: publish
+    needs: [check-version, publish]
+    if: >-
+      always() &&
+      needs.check-version.result == 'success' &&
+      (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,9 +98,14 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create "${GITHUB_REF_NAME}"
-          --repo "${GITHUB_REPOSITORY}"
-          --verify-tag
-          --generate-notes
-          --title "${GITHUB_REF_NAME}"
+        shell: bash
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub release ${GITHUB_REF_NAME} already exists"
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --verify-tag \
+              --generate-notes \
+              --title "${GITHUB_REF_NAME}"
+          fi

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: morphnext
-description: Interruptible vector morphing for Flutter.
+description: Interruptible, spring-driven vector icon morphing for Flutter without per-pair animation assets.
 version: 0.5.0
 homepage: https://kicknext.github.io/morphnext/
 repository: https://github.com/KickNext/morphnext


### PR DESCRIPTION
## What changed

- run the latest pana analyzer in CI and require zero missing pub points
- detect versions already present on pub.dev before OIDC publication
- allow the first manually published version to create its GitHub Release without a duplicate upload

## Why

pub.dev requires the first package version to be published manually. This keeps the tag workflow idempotent for that first release and for reruns.

## Verification

- dart pub publish --dry-run: 0 warnings
- actionlint
- CI will execute pana on Ubuntu