### PR TITLE
Bound the parsed font cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
         working-directory: example
 
       - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: |
+          dart format .
+          git diff --exit-code
 
       - name: Analyze
         run: flutter analyze --fatal-infos --fatal-warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,7 @@ jobs:
         working-directory: example
 
       - name: Check formatting
-        run: |
-          dart format .
-          git diff --exit-code
+        run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze
         run: flutter analyze --fatal-infos --fatal-warnings

--- a/lib/src/font/font_asset_resolver.dart
+++ b/lib/src/font/font_asset_resolver.dart
@@ -8,6 +8,8 @@ import 'binary_reader.dart';
 import 'font_selection.dart';
 import 'open_type_font.dart';
 
+const _maximumCachedFonts = 32;
+const _maximumRetainedFontBytes = 32 << 20;
 const _maximumCachedGlyphs = 256;
 const _maximumRetainedGlyphBytes = 8 << 20;
 typedef _GlyphCacheKey = (IconData, String, MorphFontSelection);
@@ -18,8 +20,11 @@ final class FontAssetResolver {
 
   final AssetBundle bundle;
   Future<List<_ManifestFamily>>? _manifest;
-  final Map<String, Future<OpenTypeFont>> _fonts =
-      <String, Future<OpenTypeFont>>{};
+  final SizedLruCache<String, Future<OpenTypeFont>> _fonts =
+      SizedLruCache<String, Future<OpenTypeFont>>(
+        maximumSize: _maximumCachedFonts,
+        maximumSizeBytes: _maximumRetainedFontBytes,
+      );
   final SizedLruCache<_GlyphCacheKey, Future<GlyphOutline>> _glyphs =
       SizedLruCache<_GlyphCacheKey, Future<GlyphOutline>>(
         maximumSize: _maximumCachedGlyphs,
@@ -166,17 +171,17 @@ final class FontAssetResolver {
   }
 
   Future<OpenTypeFont> _loadFont(String assetKey) async {
-    var future = _fonts[assetKey];
+    var future = _fonts.get(assetKey);
     if (future == null) {
       future = _readFont(assetKey);
-      _fonts[assetKey] = future;
+      _fonts.put(assetKey, future);
     }
     try {
-      return await future;
+      final font = await future;
+      _fonts.updateSizeIfSame(assetKey, future, font.bytes.lengthInBytes);
+      return font;
     } catch (_) {
-      if (identical(_fonts[assetKey], future)) {
-        _fonts.remove(assetKey);
-      }
+      _fonts.removeIfSame(assetKey, future);
       rethrow;
     }
   }

--- a/test/src/font/font_asset_resolver_test.dart
+++ b/test/src/font/font_asset_resolver_test.dart
@@ -97,6 +97,41 @@ void main() {
 
   test('parsed font assets are evicted by the bounded cache', () async {
     const retainedFontCount = 32;
+    const icons = <IconData>[
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family0'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family1'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family2'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family3'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family4'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family5'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family6'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family7'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family8'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family9'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family10'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family11'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family12'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family13'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family14'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family15'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family16'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family17'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family18'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family19'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family20'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family21'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family22'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family23'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family24'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family25'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family26'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family27'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family28'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family29'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family30'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family31'),
+      IconData(TestFontBuilder.quadraticCodePoint, fontFamily: 'Family32'),
+    ];
     final font = TestFontBuilder.trueType();
     final manifest = <String, List<String>>{};
     final assets = <String, Uint8List>{};
@@ -108,13 +143,8 @@ void main() {
     final bundle = TestAssetBundle.fonts(manifest: manifest, assets: assets);
     final resolver = FontAssetResolver(bundle);
 
-    for (var index = 0; index <= retainedFontCount; index++) {
-      await resolver.resolve(
-        IconData(
-          TestFontBuilder.quadraticCodePoint,
-          fontFamily: 'Family$index',
-        ),
-      );
+    for (final icon in icons) {
+      await resolver.resolve(icon);
     }
     expect(bundle.loadCount('assets/font_0.ttf'), 1);
 

--- a/test/src/font/font_asset_resolver_test.dart
+++ b/test/src/font/font_asset_resolver_test.dart
@@ -98,15 +98,16 @@ void main() {
   test('parsed font assets are evicted by the bounded cache', () async {
     const retainedFontCount = 32;
     final font = TestFontBuilder.trueType();
+    final manifest = <String, List<String>>{};
+    final assets = <String, Uint8List>{};
+    for (var index = 0; index <= retainedFontCount; index++) {
+      final asset = 'assets/font_$index.ttf';
+      manifest['Family$index'] = <String>[asset];
+      assets[asset] = font;
+    }
     final bundle = TestAssetBundle.fonts(
-      manifest: <String, List<String>>{
-        for (var index = 0; index <= retainedFontCount; index++)
-          'Family$index': <String>['assets/font_$index.ttf'],
-      },
-      assets: <String, Uint8List>{
-        for (var index = 0; index <= retainedFontCount; index++)
-          'assets/font_$index.ttf': font,
-      },
+      manifest: manifest,
+      assets: assets,
     );
     final resolver = FontAssetResolver(bundle);
 

--- a/test/src/font/font_asset_resolver_test.dart
+++ b/test/src/font/font_asset_resolver_test.dart
@@ -95,6 +95,41 @@ void main() {
     expect(bundle.loadCount('assets/icons.ttf'), 1);
   });
 
+  test('parsed font assets are evicted by the bounded cache', () async {
+    const retainedFontCount = 32;
+    final font = TestFontBuilder.trueType();
+    final bundle = TestAssetBundle.fonts(
+      manifest: <String, List<String>>{
+        for (var index = 0; index <= retainedFontCount; index++)
+          'Family$index': <String>['assets/font_$index.ttf'],
+      },
+      assets: <String, Uint8List>{
+        for (var index = 0; index <= retainedFontCount; index++)
+          'assets/font_$index.ttf': font,
+      },
+    );
+    final resolver = FontAssetResolver(bundle);
+
+    for (var index = 0; index <= retainedFontCount; index++) {
+      await resolver.resolve(
+        IconData(
+          TestFontBuilder.quadraticCodePoint,
+          fontFamily: 'Family$index',
+        ),
+      );
+    }
+    expect(bundle.loadCount('assets/font_0.ttf'), 1);
+
+    await resolver.resolve(
+      const IconData(
+        TestFontBuilder.compositeCodePoint,
+        fontFamily: 'Family0',
+      ),
+    );
+
+    expect(bundle.loadCount('assets/font_0.ttf'), 2);
+  });
+
   test('unique glyph streams evict old decoded outlines', () async {
     const glyphCount = 300;
     final resolver = FontAssetResolver(aliasedFixtureBundle(glyphCount));

--- a/test/src/font/font_asset_resolver_test.dart
+++ b/test/src/font/font_asset_resolver_test.dart
@@ -105,10 +105,7 @@ void main() {
       manifest['Family$index'] = <String>[asset];
       assets[asset] = font;
     }
-    final bundle = TestAssetBundle.fonts(
-      manifest: manifest,
-      assets: assets,
-    );
+    final bundle = TestAssetBundle.fonts(manifest: manifest, assets: assets);
     final resolver = FontAssetResolver(bundle);
 
     for (var index = 0; index <= retainedFontCount; index++) {
@@ -122,10 +119,7 @@ void main() {
     expect(bundle.loadCount('assets/font_0.ttf'), 1);
 
     await resolver.resolve(
-      const IconData(
-        TestFontBuilder.compositeCodePoint,
-        fontFamily: 'Family0',
-      ),
+      const IconData(TestFontBuilder.compositeCodePoint, fontFamily: 'Family0'),
     );
 
     expect(bundle.loadCount('assets/font_0.ttf'), 2);


### PR DESCRIPTION
## What changed

- replace the unbounded parsed `OpenTypeFont` map with the existing size-aware LRU cache
- retain at most 32 parsed font assets or 32 MiB of copied font bytes
- preserve concurrent-load sharing and failed-load retry behavior
- add a regression test proving the least-recently-used font is reloaded after eviction

## Why

`FontAssetResolver` already bounded decoded glyphs, sampled shapes, and morph plans, but retained every parsed font forever. Each `OpenTypeFont` owns a copy of the source bytes, so apps touching many icon font assets could grow retained memory without a limit despite morphnext documenting bounded caching.

## Verification

The regression test was first run against the previous implementation and failed with `Expected: 2, Actual: 1` after loading 33 font assets.

Final GitHub Actions checks are green:

- Dart formatting
- Flutter analyzer with fatal infos/warnings
- 115 package tests with coverage and the 90% coverage gate
- Chrome smoke test
- example tests and release web build
- `dart pub publish --dry-run`
- maximum `pana` score gate

No public API changes.